### PR TITLE
Allow extra directories in gh-pages branch

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -25,7 +25,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: build
-          clean: true
+          clean: false
           git-config-name: github-actions[bot]
           git-config-email: 41898282+github-actions[bot]@users.noreply.github.com
       - name: Debug index.html if pull request


### PR DESCRIPTION
Don't clean the deployment branch from extra stuff at every deployment.

This is to enable a workaround deployment for manually deploying a preview on GH pages for #45 pull request. The ReadTheDocs build for #45 times out.

<!-- readthedocs-preview pydocs-translation-dashboard start -->
----
📚 Documentation preview 📚: https://pydocs-translation-dashboard--47.org.readthedocs.build/

<!-- readthedocs-preview pydocs-translation-dashboard end -->