### PR TITLE
fix recent UnboundLocalError

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -62,7 +62,7 @@ def get_completion_progress() -> Iterator['LanguageProjectData']:
 
 def get_project_data(
     language: Language,
-    repo: str,
+    repo: str | None,
     languages_built: dict[str, bool],
     clones_dir: str,
     http: PoolManager,
@@ -75,6 +75,7 @@ def get_project_data(
         completion = 0.0
         translators_data = TranslatorsData(0, False)
         visitors_num = 0
+        branch = None
     return LanguageProjectData(
         language,
         repo,
@@ -93,7 +94,7 @@ def get_project_data(
 class LanguageProjectData:
     language: Language
     repository: str | None
-    branch: str
+    branch: str | None
     completion: float
     translators: TranslatorsData
     visitors: int


### PR DESCRIPTION
I noticed that the recent action runs have failed. Simply add the default value `None` for the variable `branch`, in case the repo is not found from any row in the devguide table.
<img width="1487" alt="image" src="https://github.com/user-attachments/assets/8052bffe-afd1-4f05-9ed1-1705fff97382" />


<!-- readthedocs-preview pydocs-translation-dashboard start -->
----
📚 Documentation preview 📚: https://pydocs-translation-dashboard--56.org.readthedocs.build/

<!-- readthedocs-preview pydocs-translation-dashboard end -->