### PR TITLE
Improve completion bar title

### DIFF
--- a/template.html.jinja
+++ b/template.html.jinja
@@ -37,7 +37,7 @@
   <td data-label="completion">
     <div class="progress-bar"
          style="width: {{ project.completion }}%;{% if project.change %}background: linear-gradient(to left, lightgreen {{ project.change * 100 / project.completion }}%, #4caf50 {{ project.change * 100 / project.completion }}%);{% else %}background-color: #4caf50;{% endif %}"
-         title="{{ '{:.2f}'.format(project.completion) }}%, {{ '{:.2f}'.format(project.change) }} percentage points last month"
+         title="{{ '{:.2f}'.format(project.completion) }}%, {{ '{:.2f}'.format(project.change) }}% in the last 30 days"
     >
         {{ "{:.2f}".format(project.completion) }}%
     </div>


### PR DESCRIPTION
Rather than "percentage points" use the symbol "%" and clarify "month".

<!-- readthedocs-preview pydocs-translation-dashboard start -->
----
📚 Documentation preview 📚: https://pydocs-translation-dashboard--72.org.readthedocs.build/

<!-- readthedocs-preview pydocs-translation-dashboard end --> 

 ----- 
📊 Dashboard preview 📊: https://python-docs-translations.github.io/dashboard/72/merge/