### PR TITLE
Explain "recent" part of the completion bar

### DIFF
--- a/template.html.jinja
+++ b/template.html.jinja
@@ -38,9 +38,9 @@
     <div class="progress-bar"
          style="width: {{ project.completion }}%;{% if project.change %}background: linear-gradient(to left, lightgreen {{ project.change * 100 / project.completion }}%, #4caf50 {{ project.change * 100 / project.completion }}%);{% else %}background-color: #4caf50;{% endif %}"
     >
-        {{ "{:.2f}".format(project.completion) }}% {% if project.change > 0 %}({{ '{:+.2f%}'.format(project.change) }}){% endif %}
+        {{ '{:.2f}%'.format(project.completion) }} {% if project.change > 0 %}({{ '{:+.2f%}'.format(project.change) }}){% endif %}
     </div>
-    <div class="progress-bar-outer-label">{{ "{:.2f}".format(project.completion) }}% {% if project.change > 0 %}({{ '{:+.2f%}'.format(project.change) }}){% endif %}</div>
+    <div class="progress-bar-outer-label">{{ '{:.2f%}'.format(project.completion) }} {% if project.change > 0 %}({{ '{:+.2f%}'.format(project.change) }}){% endif %}</div>
   </td>
 </tr>
 {% endfor %}

--- a/template.html.jinja
+++ b/template.html.jinja
@@ -46,7 +46,7 @@
 {% endfor %}
 </tbody>
 </table>
-<p>* total completion including recent progress, where <i>recently</i> means <i>in last 30 days</i></p>
+<p>* total completion including recent progress, where <i>recently</i> means <i>in the last 30 days</i></p>
 <p>For more information about translations, see the <a href="https://devguide.python.org/documentation/translating/" target="_blank">Python Developer’s Guide</a>.</p>
 <p>Last updated at {{ generation_time.strftime('%A, %-d %B %Y, %-H:%M:%S %Z') }} (in {{ duration // 60 }}:{{ "{:02}".format(duration % 60) }} minutes).</p>
 </body>

--- a/template.html.jinja
+++ b/template.html.jinja
@@ -38,9 +38,9 @@
     <div class="progress-bar"
          style="width: {{ project.completion }}%;{% if project.change %}background: linear-gradient(to left, lightgreen {{ project.change * 100 / project.completion }}%, #4caf50 {{ project.change * 100 / project.completion }}%);{% else %}background-color: #4caf50;{% endif %}"
     >
-        {{ "{:.2f}".format(project.completion) }}% {% if project.change > 0 %}({{ '{:.2f}'.format(project.change) }} recently){% endif %}
+        {{ "{:.2f}".format(project.completion) }}% {% if project.change > 0 %}({{ '{:.2f}'.format(project.change) }}% recently){% endif %}
     </div>
-    <div class="progress-bar-outer-label">{{ "{:.2f}".format(project.completion) }}% {% if project.change > 0 %}({{ '{:.2f}'.format(project.change) }} recently){% endif %}</div>
+    <div class="progress-bar-outer-label">{{ "{:.2f}".format(project.completion) }}% {% if project.change > 0 %}({{ '{:.2f}'.format(project.change) }}% recently){% endif %}</div>
   </td>
 </tr>
 {% endfor %}

--- a/template.html.jinja
+++ b/template.html.jinja
@@ -38,15 +38,15 @@
     <div class="progress-bar"
          style="width: {{ project.completion }}%;{% if project.change %}background: linear-gradient(to left, lightgreen {{ project.change * 100 / project.completion }}%, #4caf50 {{ project.change * 100 / project.completion }}%);{% else %}background-color: #4caf50;{% endif %}"
     >
-        {{ "{:.2f}".format(project.completion) }}% {% if project.change > 0 %}({{ '{:.2f}'.format(project.change) }}% recently){% endif %}
+        {{ "{:.2f}".format(project.completion) }}% {% if project.change > 0 %}({{ '{:+.2f%}'.format(project.change) }}){% endif %}
     </div>
-    <div class="progress-bar-outer-label">{{ "{:.2f}".format(project.completion) }}% {% if project.change > 0 %}({{ '{:.2f}'.format(project.change) }}% recently){% endif %}</div>
+    <div class="progress-bar-outer-label">{{ "{:.2f}".format(project.completion) }}% {% if project.change > 0 %}({{ '{:+.2f%}'.format(project.change) }}){% endif %}</div>
   </td>
 </tr>
 {% endfor %}
 </tbody>
 </table>
-<p>* total completion including recent progress, where <i>recently</i> means <i>in the last 30 days</i></p>
+<p>* the number in parentheses shows change in the last 30 days, included in the total progress</p>
 <p>For more information about translations, see the <a href="https://devguide.python.org/documentation/translating/" target="_blank">Python Developer’s Guide</a>.</p>
 <p>Last updated at {{ generation_time.strftime('%A, %-d %B %Y, %-H:%M:%S %Z') }} (in {{ duration // 60 }}:{{ "{:02}".format(duration % 60) }} minutes).</p>
 </body>

--- a/template.html.jinja
+++ b/template.html.jinja
@@ -36,7 +36,7 @@
   </td>
   <td data-label="completion">
     <div class="progress-bar"
-         style="width: {{ project.completion }}%;{% if project.change %}background: linear-gradient(to left, lightgreen {{ project.change * 100 / project.completion }}%, #4caf50 {{ project.change * 100 / project.completion }}%);{% else %}background-color: #4caf50;{% endif %}"
+         style="width: {{ project.completion }}%;{% if project.change %}background: linear-gradient(to left, #94cf96 {{ project.change * 100 / project.completion }}%, #4caf50 {{ project.change * 100 / project.completion }}%);{% else %}background-color: #4caf50;{% endif %}"
     >
         {{ '{:.2f}%'.format(project.completion) }} {% if project.change > 0 %}({{ '{:+.2f}%'.format(project.change) }}){% endif %}
     </div>

--- a/template.html.jinja
+++ b/template.html.jinja
@@ -13,7 +13,7 @@
   <th>language</th>
   <th>switcher</th>
   <th>translators</th>
-  <th>completion</th>
+  <th>completion*</th>
 </tr>
 </thead>
 <tbody>
@@ -37,16 +37,16 @@
   <td data-label="completion">
     <div class="progress-bar"
          style="width: {{ project.completion }}%;{% if project.change %}background: linear-gradient(to left, lightgreen {{ project.change * 100 / project.completion }}%, #4caf50 {{ project.change * 100 / project.completion }}%);{% else %}background-color: #4caf50;{% endif %}"
-         title="{{ '{:.2f}'.format(project.completion) }}%, {{ '{:.2f}'.format(project.change) }}% in the last 30 days"
     >
-        {{ "{:.2f}".format(project.completion) }}%
+        {{ "{:.2f}".format(project.completion) }}% {% if project.change > 0 %}({{ '{:.2f}'.format(project.change) }} recently){% endif %}
     </div>
-    <div class="progress-bar-outer-label">{{ "{:.2f}".format(project.completion) }}%</div>
+    <div class="progress-bar-outer-label">{{ "{:.2f}".format(project.completion) }}% {% if project.change > 0 %}({{ '{:.2f}'.format(project.change) }} recently){% endif %}</div>
   </td>
 </tr>
 {% endfor %}
 </tbody>
 </table>
+<p>* total completion including recent progress, where <i>recently</i> means <i>in last 30 days</i></p>
 <p>For more information about translations, see the <a href="https://devguide.python.org/documentation/translating/" target="_blank">Python Developer’s Guide</a>.</p>
 <p>Last updated at {{ generation_time.strftime('%A, %-d %B %Y, %-H:%M:%S %Z') }} (in {{ duration // 60 }}:{{ "{:02}".format(duration % 60) }} minutes).</p>
 </body>

--- a/template.html.jinja
+++ b/template.html.jinja
@@ -48,7 +48,7 @@
 {% endfor %}
 </tbody>
 </table>
-<p>* the number in parentheses shows change in the last 30 days, included in the total progress</p>
+<p>* the number in parentheses shows change in the last 30 days, included in the total completion</p>
 <p>For more information about translations, see the <a href="https://devguide.python.org/documentation/translating/" target="_blank">Python Developer’s Guide</a>.</p>
 <p>Last updated at {{ generation_time.strftime('%A, %-d %B %Y, %-H:%M:%S %Z') }} (in {{ duration // 60 }}:{{ "{:02}".format(duration % 60) }} minutes).</p>
 </body>

--- a/template.html.jinja
+++ b/template.html.jinja
@@ -40,7 +40,9 @@
     >
         {{ '{:.2f}%'.format(project.completion) }} {% if project.change > 0 %}({{ '{:+.2f%}'.format(project.change) }}){% endif %}
     </div>
-    <div class="progress-bar-outer-label">{{ '{:.2f%}'.format(project.completion) }} {% if project.change > 0 %}({{ '{:+.2f%}'.format(project.change) }}){% endif %}</div>
+    <div class="progress-bar-outer-label">
+        {{ '{:.2f%}'.format(project.completion) }} {% if project.change > 0 %}({{ '{:+.2f%}'.format(project.change) }}){% endif %}
+    </div>
   </td>
 </tr>
 {% endfor %}

--- a/template.html.jinja
+++ b/template.html.jinja
@@ -38,10 +38,10 @@
     <div class="progress-bar"
          style="width: {{ project.completion }}%;{% if project.change %}background: linear-gradient(to left, lightgreen {{ project.change * 100 / project.completion }}%, #4caf50 {{ project.change * 100 / project.completion }}%);{% else %}background-color: #4caf50;{% endif %}"
     >
-        {{ '{:.2f}%'.format(project.completion) }} {% if project.change > 0 %}({{ '{:+.2f%}'.format(project.change) }}){% endif %}
+        {{ '{:.2f}%'.format(project.completion) }} {% if project.change > 0 %}({{ '{:+.2f}%'.format(project.change) }}){% endif %}
     </div>
     <div class="progress-bar-outer-label">
-        {{ '{:.2f%}'.format(project.completion) }} {% if project.change > 0 %}({{ '{:+.2f%}'.format(project.change) }}){% endif %}
+        {{ '{:.2f}%'.format(project.completion) }} {% if project.change > 0 %}({{ '{:+.2f}%'.format(project.change) }}){% endif %}
     </div>
   </td>
 </tr>

--- a/template.html.jinja
+++ b/template.html.jinja
@@ -57,8 +57,9 @@
     document.querySelectorAll('.progress-bar').forEach(progressBar => {
       const textWidth = progressBar.scrollWidth;
       const barWidth = progressBar.offsetWidth;
+      const padding = 6;
 
-      if (barWidth < textWidth) {
+      if (barWidth < textWidth + padding) {
         progressBar.classList.add('low');
       } else {
         progressBar.classList.remove('low');

--- a/template.html.jinja
+++ b/template.html.jinja
@@ -57,9 +57,8 @@
     document.querySelectorAll('.progress-bar').forEach(progressBar => {
       const textWidth = progressBar.scrollWidth;
       const barWidth = progressBar.offsetWidth;
-      const padding = 6;
 
-      if (barWidth < textWidth + padding) {
+      if (barWidth < textWidth) {
         progressBar.classList.add('low');
       } else {
         progressBar.classList.remove('low');


### PR DESCRIPTION
Make the completion bar with the recent progress part self-explanatory. That way the visualisation should be more understandable, and the whole table more informative.

cc @encukou 

 ----- 
📊 Dashboard preview 📊: https://python-docs-translations.github.io/dashboard/73/merge/