### PR TITLE
Progress bar label script refactor

### DIFF
--- a/template.html.jinja
+++ b/template.html.jinja
@@ -53,10 +53,10 @@
 <script>
   function updateProgressBarVisibility() {
     document.querySelectorAll('.progress-bar').forEach(progressBar => {
-      const textWidth = progressBar.scrollWidth;
+      const barWithOverflowWidth = progressBar.scrollWidth;
       const barWidth = progressBar.offsetWidth;
 
-      if (barWidth < textWidth) {
+      if (barWidth < barWithOverflowWidth) {
         progressBar.classList.add('low');
       } else {
         progressBar.classList.remove('low');

--- a/template.html.jinja
+++ b/template.html.jinja
@@ -54,7 +54,7 @@
   function updateProgressBarVisibility() {
     document.querySelectorAll('.progress-bar').forEach(progressBar => {
       const barWithOverflowWidth = progressBar.scrollWidth;
-      const barWidth = progressBar.offsetWidth;
+      const barWidth = progressBar.clientWidth;
 
       if (barWidth < barWithOverflowWidth) {
         progressBar.classList.add('low');


### PR DESCRIPTION
* rename textWidth variable to barWithOverflowWidth (more accurate)
* use clientWidth instead of offsetWidth -- It seems better since we don't use padding attribute, and scrollWidth wouldn't include it anyway. 

 ----- 
📊 Dashboard preview 📊: https://python-docs-translations.github.io/dashboard/76/merge/