### PR TITLE
Add links to source and download

### DIFF
--- a/metadata.html.jinja
+++ b/metadata.html.jinja
@@ -37,10 +37,6 @@
 </tbody>
 </table>
 <p>* number of Sphinx build process warnings</p>
-<footer>
-  <hr>
-  <p>You can find the scripts used to generate this page <a href="https://github.com/python-docs-translations/dashboard">here</a>.</p>
   <p>Last updated at {{ generation_time.strftime('%A, %-d %B %Y, %-H:%M:%S %Z') }} (in {{ duration // 60 }}:{{ "{:02}".format(duration % 60) }} minutes).</p>
-</footer>
 </body>
 </html>

--- a/metadata.html.jinja
+++ b/metadata.html.jinja
@@ -37,7 +37,10 @@
 </tbody>
 </table>
 <p>* number of Sphinx build process warnings</p>
-<p>For more information about translations, see the <a href="https://devguide.python.org/documentation/translating/">Python Developer’s Guide</a>.</p>
-<p>Last updated at {{ generation_time.strftime('%A, %-d %B %Y, %-H:%M:%S %Z') }} (in {{ duration // 60 }}:{{ "{:02}".format(duration % 60) }} minutes).</p>
+<footer>
+  <hr>
+  <p>You can find the scripts used to generate this page <a href="https://github.com/python-docs-translations/dashboard">here</a>.</p>
+  <p>Last updated at {{ generation_time.strftime('%A, %-d %B %Y, %-H:%M:%S %Z') }} (in {{ duration // 60 }}:{{ "{:02}".format(duration % 60) }} minutes).</p>
+</footer>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -13,6 +13,9 @@ th, td {
 th {
   background-color: #f4f4f4;
 }
+hr {
+  color: #f4f4f4;
+}
 .progress-bar {
   display: inline-block;
   color: white;

--- a/template.html.jinja
+++ b/template.html.jinja
@@ -53,17 +53,15 @@ main | <a href="metadata.html" target="_self">meta</a>
 </tbody>
 </table>
 <p>* the number in parentheses shows change in the last 30 days, included in the total completion</p>
-<h3>Python Documentation</h3>
 <p>
-  Currently being translated into <strong>{{ completion_progress|length }}</strong> languages.
-  The documentation has a word count of {{ '{:,}'.format(word_count) }}.
-  For more information about translations, see the <a href="https://devguide.python.org/documentation/translating/">Python Developer’s Guide</a> and <a href="https://peps.python.org/pep-0545/">PEP 545</a>.
+Currently being translated into {{ completion_progress|length }} languages.
+The documentation has a total word count of {{ '{:,}'.format(word_count) }}.
+For more information about translations, see the <a href="https://devguide.python.org/documentation/translating/">Python Developer’s Guide</a>.
 </p>
-<footer>
-  <hr>
-  <p>You can download the data on this page in <code>.json</code> format <a href="https://github.com/python-docs-translations/dashboard/blob/gh-pages/index.json">here</a>, and you can also find the scripts used to generate this page <a href="https://github.com/python-docs-translations/dashboard">here</a>.
-  <p>Last updated at {{ generation_time.strftime('%A, %-d %B %Y, %-H:%M:%S %Z') }} (in {{ duration // 60 }}:{{ "{:02}".format(duration % 60) }} minutes).</p>
-</footer>
+<hr>
+<p>You can download the data on this page in <a href="https://github.com/python-docs-translations/dashboard/blob/gh-pages/index.json">JSON format</a>.</p>
+<p>You can also find the scripts used to generate these pages <a href="https://github.com/python-docs-translations/dashboard">here</a>.</p>
+<p>Last updated at {{ generation_time.strftime('%A, %-d %B %Y, %-H:%M:%S %Z') }} (in {{ duration // 60 }}:{{ "{:02}".format(duration % 60) }} minutes).</p>
 </body>
 <script>
   function updateProgressBarVisibility() {

--- a/template.html.jinja
+++ b/template.html.jinja
@@ -53,9 +53,17 @@ main | <a href="metadata.html" target="_self">meta</a>
 </tbody>
 </table>
 <p>* the number in parentheses shows change in the last 30 days, included in the total completion</p>
-<p>The Python documentation currently has a word count of {{ '{:,}'.format(word_count) }}.</p>
-<p>For more information about translations, see the <a href="https://devguide.python.org/documentation/translating/">Python Developer’s Guide</a>.</p>
-<p>Last updated at {{ generation_time.strftime('%A, %-d %B %Y, %-H:%M:%S %Z') }} (in {{ duration // 60 }}:{{ "{:02}".format(duration % 60) }} minutes).</p>
+<h3>Python Documentation</h3>
+<p>
+  Currently being translated into <strong>{{ completion_progress|length }}</strong> languages.
+  The documentation has a word count of {{ '{:,}'.format(word_count) }}.
+  For more information about translations, see the <a href="https://devguide.python.org/documentation/translating/">Python Developer’s Guide</a> and <a href="https://peps.python.org/pep-0545/">PEP 545</a>.
+</p>
+<footer>
+  <hr>
+  <p>You can download the data on this page in <code>.json</code> format <a href="https://github.com/python-docs-translations/dashboard/blob/gh-pages/index.json">here</a>, and you can also find the scripts used to generate this page <a href="https://github.com/python-docs-translations/dashboard">here</a>.
+  <p>Last updated at {{ generation_time.strftime('%A, %-d %B %Y, %-H:%M:%S %Z') }} (in {{ duration // 60 }}:{{ "{:02}".format(duration % 60) }} minutes).</p>
+</footer>
 </body>
 <script>
   function updateProgressBarVisibility() {


### PR DESCRIPTION
Also added translations count and split the footer from the informational text. 

 ----- 
📊 Dashboard preview 📊: https://python-docs-translations.github.io/dashboard/83/merge/