### PR TITLE
Add deptry in pre-commit config and two new requirements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,5 +40,11 @@ repos:
       - id: mypy
         additional_dependencies: [types-docutils, types-polib>=1.2.0.20250114, types-requests]
 
+  - repo: https://github.com/francescorubbo/deptry-pre-commit
+    rev: v0.23.0
+    hooks:
+      - id: deptry
+        args: ["--per-rule-ignores", "DEP002=python-docs-theme", "--package-module-name-map", "gitpython=git,sphinx-lint=sphinxlint"]
+
 ci:
   autoupdate_schedule: quarterly

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 gitpython
+urllib3
 potodo
+polib
 jinja2
 docutils
 sphinx


### PR DESCRIPTION
Follow-up for #90.

The requirements were transitive, but we are using them directly, so they should be in the requirements.

