### PR TITLE
Fix (and improve) `sphinx-lint` log

### DIFF
--- a/sphinx_lint.py
+++ b/sphinx_lint.py
@@ -7,8 +7,11 @@ from sphinxlint import check_file, checkers
 
 def store_and_count_failures(clones_dir: str, repo: str, language_code: str) -> int:
     failed_checks = list(chain.from_iterable(yield_failures(clones_dir, repo)))
-    filepath = Path(f'warnings-lint-{language_code}.txt')
-    filepath.write_text('\n'.join([str(c) for c in failed_checks]))
+    log = '\n'.join([str(c) for c in failed_checks]).replace(
+        str(Path(clones_dir, 'rebased_translations', repo)) + '/', ''
+    )
+    filepath = Path(f'build/warnings-lint-{language_code}.txt')
+    filepath.write_text(log)
     return len(failed_checks)
 
 


### PR DESCRIPTION
These files were not updated, since they were not moved to the `build` directory! This highlights the importance of a header, though I am not quite sure what format it should get.