### PR TITLE
Simplify `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-index.html
-metadata.html
-warnings-*.txt
+build
 clones
+venv


### PR DESCRIPTION
The files are now placed in `/build` at generation and do not need to be moved there.