### PR TITLE
Test `repositories.py`

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -96,7 +96,7 @@ if __name__ == '__main__':
     logging.info(f'starting at {generation_time}')
     Path('build').mkdir(parents=True, exist_ok=True)
 
-    completion_progress = list(get_completion_progress())
+    from data import completion_progress
 
     env = Environment(loader=FileSystemLoader('templates'))
     index = env.get_template('index.html.jinja').render(

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -1,0 +1,57 @@
+import unittest
+import support
+import tempfile
+import shutil
+
+from pathlib import Path
+from git import Repo
+
+with support.import_scripts():
+    import repositories
+    from repositories import Language
+
+
+class testRepositories(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = tempfile.mkdtemp()
+        cls.test_repo_path = Path(cls.tempdir) / 'devguide'
+        cls.test_repo = Repo.clone_from(
+            'https://github.com/python/devguide',
+            cls.test_repo_path,
+            branch='main',
+            depth=1,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tempdir)
+
+    def test_get_languages_and_repos(self):
+        result = list(repositories.get_languages_and_repos(self.test_repo_path))
+
+        for entry in result:
+            info, repo = entry
+            self.assertIsInstance(info, Language)
+
+        self.assertIn(
+            (Language(code='tr', name='Turkish'), 'python/python-docs-tr'), result
+        )
+        self.assertIn(
+            (Language(code='es', name='Spanish'), 'python/python-docs-es'), result
+        )
+        self.assertIn(
+            (Language(code='pl', name='Polish'), 'python/python-docs-pl'), result
+        )
+        self.assertIn(
+            (
+                Language(code='zh-tw', name='Traditional Chinese'),
+                'python/python-docs-zh-tw',
+            ),
+            result,
+        )
+        self.assertIn(
+            (Language(code='it', name='Italian'), 'python/python-docs-it'), result
+        )
+
+        self.assertGreater(len(result), 23 - 1)


### PR DESCRIPTION
Also, fix warnings:
```
repositories.py:20: PendingDeprecationWarning: nodes.Node.traverse() is obsoleted by Node.findall().
  for node in doctree.traverse(table):
repositories.py:21: PendingDeprecationWarning: nodes.Node.traverse() is obsoleted by Node.findall().
  for row_node in node.traverse(row)[1:]:
```